### PR TITLE
Adjust secondary motor control in ShooterSubsystem2 to 0.6

### DIFF
--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem2.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem2.java
@@ -81,7 +81,14 @@ public class ShooterSubsystem2 extends SubsystemBase{
 
     public void setFlywheelVelocityAmp(double velocity) {
         m_primaryMotor.setControl(m_velocityVoltage.withVelocity(velocity));
-        m_secondaryMotor.setControl(m_velocityVoltage.withVelocity(velocity*0.80));
+        m_secondaryMotor.setControl(m_velocityVoltage.withVelocity(velocity*0.60));
+        /* 
+            | 0.80 |   Worked at practice field, not event
+            | 0.70 |
+            | 0.60 |
+            | 0.50 |
+            | 0.40 |
+         */
     }
 
     public void setFlywheelToIdle() {


### PR DESCRIPTION
Updated the control of the secondary motor in the ShooterSubsystem2 class to use a velocity of `velocity*0.60` instead of `velocity*0.80`. Added comments with different velocity values for reference.