### PR TITLE
Updated index information

### DIFF
--- a/src/main/java/frc/robot/commands/IntakeRevCommandGroup.java
+++ b/src/main/java/frc/robot/commands/IntakeRevCommandGroup.java
@@ -4,6 +4,7 @@ import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.subsystems.IndexSubsystem;
 import frc.robot.subsystems.IntakeSubsystem;
+import frc.robot.util.IndexConstants;
 
 public class IntakeRevCommandGroup extends SequentialCommandGroup {
     // LED to unloaded color
@@ -22,10 +23,9 @@ public class IntakeRevCommandGroup extends SequentialCommandGroup {
         addCommands(
                 new ParallelCommandGroup(
                     // Run Intake in reverse
-                
                     new SetIntake(intake, 0.75),  
                     // Run Index in reverse
-                    new SetIndex(index, -0.75)
+                    new SetIndex(index, IndexConstants.INDEX_POWER_REV)
         ));
 
     }

--- a/src/main/java/frc/robot/subsystems/IndexSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IndexSubsystem.java
@@ -24,6 +24,10 @@ public class IndexSubsystem extends SubsystemBase {
         motor.set(ControlMode.PercentOutput, IndexConstants.INDEX_POWER);
     }
 
+    public void runIndexingReverse() {
+        motor.set(ControlMode.PercentOutput, IndexConstants.INDEX_POWER_REV);
+    }
+
     public boolean hasCargo() {
         return NoteSensor.isNoteLoaded();
     }

--- a/src/main/java/frc/robot/util/IndexConstants.java
+++ b/src/main/java/frc/robot/util/IndexConstants.java
@@ -3,7 +3,7 @@ package frc.robot.util;
 public class IndexConstants {
     // Tested in Tuner: Negative value is red, and brings in the note
     // Previously -1.0 and it was going into the flywheels, but some changes have been made. -0.5 was too little and causing jams
-    public static final double INDEX_POWER = -0.55;  
+    public static final double INDEX_POWER = -0.75; // -0.55  
     public static final double INDEX_POWER_REV = 0.75;
 
         


### PR DESCRIPTION
- Missed named branch "Intake" Adjustment when it was really an `index` adjustment 
- Changed the IntakeREV command group to use the IndexConstant for reversing index power (was incorrect before).
- Added a runIndexingReverse method to IndexSubststem class. 
- Increased Index power from 0.55 to 0.75